### PR TITLE
Fix bug in HLS streamer where the final segment fails to play or stream

### DIFF
--- a/helpers/playlistGenerator.js
+++ b/helpers/playlistGenerator.js
@@ -20,6 +20,17 @@ const playListGenerator = (videoFileSize, segmentSize, fileExtension, videoDurat
     for (let sequence = 0; sequence < segmentsCount; sequence++) {
         playListBody = playListBody + segmentTemplate(sequence, fileExtension, segmentDuration, mediaName, stream);
     };
+    if (segmentsCount * segmentSize < videoFileSize) {
+      playListBody =
+        playListBody +
+        segmentTemplate(
+          segmentsCount + "-end",
+          fileExtension,
+          (videoDurationInSeconds - segmentDuration * segmentsCount).toFixed(2),
+          mediaName,
+          stream
+        );
+    }
     return playListStart + playListBody + playListEnd;
 };
 


### PR DESCRIPTION
**Problem**
We identified a critical bug in our HLS streaming implementation where the final segment of a stream fails to play or stream under specific scenarios. This issue was affecting the viewer's experience, especially in cases of closely timed live events or content that runs right up to the last segment.

**Solution**
This merge request introduces a fix that ensures the final segment of the HLS stream is correctly processed and played. The modifications include adjustments to the segment handling logic to ensure the last part of the stream is not omitted or dropped during the streaming process.
